### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the Jitpack repository:
 Add the dependency:
 
     dependencies {
-        compile 'com.github.TimCastelijns:ChatExchange:version'
+        implementation 'com.github.TimCastelijns:ChatExchange:version'
     }
 
 Where `version` should be equal to that of the jitpack badge above.


### PR DESCRIPTION
Changed from "compile" to "implementation" since the former is obsolete and will be removed by the end of 2018.